### PR TITLE
Issue/2/crawl backtracking bug

### DIFF
--- a/tests/friendCrawler_test.py
+++ b/tests/friendCrawler_test.py
@@ -3,27 +3,71 @@ from tests.mockSteamApi import MockSteamApi
 from three_games.steamApi import SteamApi
 from three_games.friendCrawler import FriendCrawler
 
-
-
-
 def test_crawl():
+
+    # RocketLeague player and all-around awesome dude who suggestsed that
+    # game (^^) as a good userbase for testing this project. 
+    STEAM_USER_CRNXX = "crnxx"
+
+    # TODO: Try some simpler, closed circle graphs with a large 
+    #       radius, as a way to test graph_depth. Different 
+    #       centers (steamid parameter) should produce the same
+    #       graph G (i.e. neo4j objects)
 
     crawler = FriendCrawler(MockSteamApi())
 
     center = crawler.build_friend_graph(steamid=3, graph_depth=6)
-    # output_player(player=center, level=0)
+    output_player(player=center, level=0)
 
+    # The entry node of the graph is Carl
     assert(center.steamid == '3')
-    assert(len(center.friends) == 2)
+    assert(center.realname == 'Carl')
+    carl = center
+
+    # Carl should have two friends: 1 (Alice) and 4 (Debra)
+    assert(len(carl.friends) == 2)
     assert([f.steamid for f in center.friends] == ['1', '4'])
 
+    # Alice should be a friend of Carl and a node
+    alice = get_friend_by_steamid(carl, '1')
+    assert(alice.realname == 'Alice')
+    # Alice should have two friends: 2 (Bob), 3 (Carl)
+    assert([f.steamid for f in alice.friends] == ['2', '3'])
+
+    # Debra should be a friend of Carl and a node
+    debra = get_friend_by_steamid(carl, '4')
+    assert(debra.realname == 'Debra')
+    # Debra should have three friends: 2 (Bob), 3 (Carl), and 5 (Eustice)
+    assert([f.steamid for f in debra.friends] == ['2', '3', '5'])
+
+    # Bob should be a friend of Debra and a node
+    bob = get_friend_by_steamid(debra, '2')
+    assert(bob.realname == 'Bob')
+    # Bob should have two friends: 1 (Alice), 4 (Debra)
+    assert([f.steamid for f in bob.friends] == ['1', '4'])
+
+    # Carl should be Debra's friend
+    assert(carl == get_friend_by_steamid(debra, '3'))
+
+    # Eustice should be a friend of Debra and a node
+    eustice = get_friend_by_steamid(debra, '5')
+    # Debra should be her only friend
+    assert([f.steamid for f in eustice.friends] == ['4'])
+    assert(eustice.realname == 'Eustice')
+    # Debra should be Eustice's friend
+    assert(debra == get_friend_by_steamid(eustice, '4'))
+
+
+def get_friend_by_steamid(player, steamid):
+    for friend in player.friends:
+        if friend.steamid == steamid:
+            return friend
+    return None
 
 def output_player(player, level):
-
     if level > 3:
         return
-
-    print('\t' * level, player.steamid, player.personaname,
-          player.realname, 'friends:', len(player.friends))
+    print('{}#{} - {} has {} friends'.format(
+        '\t'* level, player.steamid, player.realname, len(player.friends)))
     for friend in player.friends:
         output_player(friend, level + 1)

--- a/tests/friendCrawler_test.py
+++ b/tests/friendCrawler_test.py
@@ -8,28 +8,13 @@ from three_games.friendCrawler import FriendCrawler
 STEAM_USER_CRNXX = "crnxx"
 
 
-def test_deep_crawl():
+def test_crawl():
 
     GRAPH_DEPTH = 6
 
     crawler = FriendCrawler(MockSteamApi())
 
-    center = crawler.build_friend_graph(steamid=3, graph_depth=GRAPH_DEPTH)
-    output_player(player=center, level=0)
-
-    perform_graph_assertions(center)
-
-
-def test_shallow_crawl():
-    """ Try some simpler, closed circle graphs with a large radius, 
-        as a way to test graph_depth. Different centers (steamid 
-        parameter) should produce the same graph G (i.e. neo4j objects)
-    """
-    GRAPH_DEPTH = 3
-
-    crawler = FriendCrawler(MockSteamApi())
-
-    center = crawler.build_friend_graph(steamid=3, graph_depth=GRAPH_DEPTH)
+    center = crawler.build_friend_graph(steamid=3)
     output_player(player=center, level=0)
 
     perform_graph_assertions(center)
@@ -54,8 +39,8 @@ def perform_graph_assertions(center):
     # Debra should be a friend of Carl and a node
     debra = get_friend_by_steamid(carl, '4')
     assert(debra.realname == 'Debra')
-    # Debra should have three friends: 1 (Alice), 3 (Carl), and 5 (Eustice)
-    assert([f.steamid for f in debra.friends] == ['1', '3', '5'])
+    # Debra should have three friends: 2 (Bob), 3 (Carl), and 5 (Eustace)
+    assert([f.steamid for f in debra.friends] == ['2', '3', '5'])
 
     # Bob should be a friend of Debra and a node
     bob = get_friend_by_steamid(debra, '2')
@@ -66,13 +51,13 @@ def perform_graph_assertions(center):
     # Carl should be Debra's friend
     assert(carl == get_friend_by_steamid(debra, '3'))
 
-    # Eustice should be a friend of Debra and a node
-    eustice = get_friend_by_steamid(debra, '5')
+    # Eustace should be a friend of Debra and a node
+    eustace = get_friend_by_steamid(debra, '5')
     # Debra should be her only friend
-    assert([f.steamid for f in eustice.friends] == ['4'])
-    assert(eustice.realname == 'Eustice')
-    # Debra should be Eustice's friend
-    assert(debra == get_friend_by_steamid(eustice, '4'))
+    assert([f.steamid for f in eustace.friends] == ['4'])
+    assert(eustace.realname == 'Eustace')
+    # Debra should be Eustace's friend
+    assert(debra == get_friend_by_steamid(eustace, '4'))
 
 
 def get_friend_by_steamid(player, steamid):
@@ -85,7 +70,7 @@ def get_friend_by_steamid(player, steamid):
 def output_player(player, level):
     if level > 3:
         return
-    print('{}#{} - {} has {} friends'.format(
-        '\t' * level, player.steamid, player.realname, len(player.friends)))
+    print('{} {} has {} friends'.format(
+        '\t' * level, player, len(player.friends)))
     for friend in player.friends:
         output_player(friend, level + 1)

--- a/tests/mockSteamApi.py
+++ b/tests/mockSteamApi.py
@@ -28,11 +28,11 @@ class MockSteamApi(SteamApi):
         return MockSteamApi.GAMES_RESPONSE_PER_STEAMID[steamid]
 
     PLAYER_LIST = {
-        '1': {"steamid": "1", "personaname": "player_one", "realname": "Player One"},
-        '2': {"steamid": "2", "personaname": "player_two", "realname": "Player Two"},
-        '3': {"steamid": "3", "personaname": "player_three", "realname": "Player Three"},
-        '4': {"steamid": "4", "personaname": "player_four", "realname": "Player Four"},
-        '5': {"steamid": "5", "personaname": "player_five", "realname": "Player Five"},
+        '1': {"steamid": "1", "personaname": "player_one", "realname": "Alice"},
+        '2': {"steamid": "2", "personaname": "player_two", "realname": "Bob"},
+        '3': {"steamid": "3", "personaname": "player_three", "realname": "Carl"},
+        '4': {"steamid": "4", "personaname": "player_four", "realname": "Debra"},
+        '5': {"steamid": "5", "personaname": "player_five", "realname": "Eustice"},
     }
 
     def get_player_summaries(self, steamids):

--- a/tests/mockSteamApi.py
+++ b/tests/mockSteamApi.py
@@ -32,7 +32,7 @@ class MockSteamApi(SteamApi):
         '2': {"steamid": "2", "personaname": "player_two", "realname": "Bob"},
         '3': {"steamid": "3", "personaname": "player_three", "realname": "Carl"},
         '4': {"steamid": "4", "personaname": "player_four", "realname": "Debra"},
-        '5': {"steamid": "5", "personaname": "player_five", "realname": "Eustice"},
+        '5': {"steamid": "5", "personaname": "player_five", "realname": "Eustace"},
     }
 
     def get_player_summaries(self, steamids):

--- a/tests/steamApi_test.py
+++ b/tests/steamApi_test.py
@@ -28,11 +28,11 @@ def test_get_player_summaries():
     api = MockSteamApi()
 
     single_result = api.get_player_summary(3)
-    assert single_result['realname'] == 'Player Three'
+    assert single_result['realname'] == 'Carl'
 
     multiple_results = api.get_player_summaries([2, 3])
-    assert multiple_results[0]['realname'] == 'Player Two'
-    assert multiple_results[1]['realname'] == 'Player Three'
+    assert multiple_results[0]['realname'] == 'Bob'
+    assert multiple_results[1]['realname'] == 'Carl'
 
 
 def test_get_owned_games():

--- a/three_games/friendCrawler.py
+++ b/three_games/friendCrawler.py
@@ -3,8 +3,6 @@ from three_games.game import OwnedGame
 
 class FriendCrawler(object):
 
-    # TODO: Check out Teepeeh's steam id as a good potential graph
-
     def __init__(self, steam_api):
         self.api = steam_api
 

--- a/three_games/player.py
+++ b/three_games/player.py
@@ -24,6 +24,12 @@ class Player(object):
 
         self.games = []
 
+    def __str__(self):
+        return '{}: {}'.format(self.steamid, self.realname)
+
+    def __repr__(self):
+        return str(self)
+
     def add_friend(self, other_player):
         self.friends.append(other_player)
 


### PR DESCRIPTION
Replaces previous Depth-First graph traversal with Breadth-first.
That also made the recursion depth obsolete. That limit will come back in client-side API throttling, see #6 

Fixes #2 