### PR TITLE
Fix for intermittent test failure

### DIFF
--- a/tests/steamApi_test.py
+++ b/tests/steamApi_test.py
@@ -104,13 +104,12 @@ def test_build_owned_games_url():
     expected = (
         'http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001'
         '?key=DUMMY_KEY&format=json&steamid=100'
+        '&include_appinfo=1&include_played_free_games=1'
     )
 
     url = SteamApi.build_owned_games_url("DUMMY_KEY", 100, True, True)
 
-    assert expected in url
-    assert '&include_appinfo=1' in url
-    assert '&include_played_free_games=1' in url
+    assert expected == url
 
 
 def test_build_friend_list_url():

--- a/three_games/steamApi.py
+++ b/three_games/steamApi.py
@@ -66,7 +66,7 @@ class SteamApi(object):
         return resp.json()['response']['players']
 
     def get_owned_games(self, steamid):
-        url = SteamApi.build_owned_games_url(self.api_key, steam_id, True, True)
+        url = SteamApi.build_owned_games_url(self.api_key, steamid, True, True)
 
         logging.debug('get_owned_games({})'.format(steamid))
         resp = self.__get__(url, OWNED_GAMES_LIMIT_EXCEEDED)
@@ -153,8 +153,7 @@ class SteamApi(object):
             api_key, steam_id,
             include_appinfo=True, include_played_free_games=True):
 
-        builder = SteamApi.UrlBuilder()
-        builder.with_key(api_key)
+        builder = SteamApi.UrlBuilder.create(api_key)
         builder.with_steam_id(steam_id)
         builder.with_function(SteamApi.FUNCTION_OWNED_GAMES)
         builder.with_version('0001')
@@ -238,8 +237,9 @@ class SteamApi(object):
                 url += '&steamids={}'.format(
                     ','.join((str(x) for x in self.steam_ids)))
 
-            # Add free-form params
+            # Add free-form params.
+            # NOTE: Sorting by key to make this method deterministic and simpler to test.
             url += ''.join(['&{}={}'.format(key, self.params[key])
-                            for key in self.params])
+                            for key in sorted(self.params)])
 
             return url


### PR DESCRIPTION
Now sorting SteamApi parameters when I build a URL to provide a deterministic feature for testing.
Cleaned up a unit test that was failing intermittently.